### PR TITLE
Fixed helper import statement to reflect package structure

### DIFF
--- a/shifterator/relative_shift.py
+++ b/shifterator/relative_shift.py
@@ -12,7 +12,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 import shifterator.shifterator as shifterator
-from shifterator.helper import *
+from shifterator.shifterator.helper import *
 
 # ------------------------------------------------------------------------------
 # --------------------------- Relative shift classes ---------------------------


### PR DESCRIPTION
To remedy `ModuleNotFoundError: No module named 'shifterator.helper'` when attempting to use functions, such as `entropy_shift`, from `relative_shift.py`

