### PR TITLE
fix matplotlib warning

### DIFF
--- a/shifterator/plotting.py
+++ b/shifterator/plotting.py
@@ -601,6 +601,7 @@ def set_ticks(ax, top_n, plot_params):
         x_ticks = [tick_format.format(t) for t in ax.get_xticks()]
     else:
         x_ticks = [tick_format.format(abs(t)) for t in ax.get_xticks()]
+    ax.set_xticks(ax.get_xticks())
     ax.set_xticklabels(x_ticks, fontsize=plot_params["xtick_fontsize"])
     # Flip y-axis tick labels and make sure every 5th tick is labeled
     y_ticks = list(range(1, top_n, plot_params["every_nth_ytick"])) + [top_n]


### PR DESCRIPTION
Calling `get_shift_graph` gives a warning when used with matplotlib 3.3+:

    UserWarning: FixedFormatter should only be used together with FixedLocator

[This issue](https://github.com/matplotlib/matplotlib/issues/18848) explains why the warning occurs and suggests setting xticks first before setting xticklabels, which is what this PR does.