### PR TITLE
Label ProportionShift top bars with system names (#47)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt") as f:
 
 setuptools.setup(
     name="shifterator",
-    version="0.5.0",
+    version="0.5.1",
     author="Ryan J. Gallagher",
     author_email="gallagher.r@northeastern.edu",
     description="Interpretable data visualizations for understanding how texts differ at the word level",

--- a/shifterator/__init__.py
+++ b/shifterator/__init__.py
@@ -8,3 +8,4 @@ from .shifts import (
 )
 
 name = "shifterator"
+__version__ = "0.5.1"

--- a/shifterator/plotting.py
+++ b/shifterator/plotting.py
@@ -23,6 +23,7 @@ def get_plot_params(plot_params, show_score_diffs, diff):
         "height": 15,
         "invisible_spines": [],
         "label_fontsize": 13,
+        "label_total_with_system_names": False,
         "missing_symbol": "*",
         "pos_cumulative_inset": [0.19, 0.12, 0.175, 0.175],
         "pos_text_size_inset": [0.81, 0.12, 0.08, 0.08],
@@ -74,6 +75,13 @@ def get_plot_params(plot_params, show_score_diffs, diff):
         "total": r"$\Sigma$",
     }
     defaults.update(plot_params)
+    # Label the total contribution bars with the system names. This is used by
+    # shifts whose +/- contributions correspond to the two systems (e.g.
+    # ProportionShift), so the top bars are labeled like the JSD shift graph
+    # without flipping bar directions via `all_pos_contributions`.
+    if defaults["label_total_with_system_names"]:
+        defaults["symbols"]["neg_total"] = defaults["system_names"][0]
+        defaults["symbols"]["pos_total"] = defaults["system_names"][1]
     return defaults
 
 

--- a/shifterator/shifts.py
+++ b/shifterator/shifts.py
@@ -124,6 +124,12 @@ class ProportionShift(Shift):
     ):
         if title is None:
             title = ""
+        # A type's contribution is positive or negative depending on which
+        # system it is more prevalent in, so label the total contribution bars
+        # with the system names (see issue #47). We do not set
+        # `all_pos_contributions`, which would force every bar to point the same
+        # direction since proportion shift scores already carry their sign.
+        kwargs.setdefault("label_total_with_system_names", True)
         ax = super().get_shift_graph(
             top_n=top_n,
             text_size_inset=text_size_inset,

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1,11 +1,11 @@
-"""Tests for fixes to GitHub issues #11, #26, #38."""
+"""Tests for fixes to GitHub issues #11, #26, #38, #47."""
 
 import matplotlib
 matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt
 import pytest
-from shifterator import WeightedAvgShift, EntropyShift
+from shifterator import WeightedAvgShift, EntropyShift, ProportionShift
 
 
 @pytest.fixture(autouse=True)
@@ -138,3 +138,52 @@ class TestIssue38FontFamily:
         shift = WeightedAvgShift(freq1, freq2, type2score_1=scores)
         ax = shift.get_shift_graph(top_n=2, show_plot=False)
         assert ax is not None
+
+
+# ---------------------------------------------------------------------------
+# Issue #47: ProportionShift should label the top bars with the system names
+# ---------------------------------------------------------------------------
+
+class TestIssue47ProportionShiftSystemNames:
+    freq1 = {"happy": 20, "sad": 5, "the": 50, "good": 15, "bad": 10}
+    freq2 = {"happy": 10, "sad": 15, "the": 45, "good": 5, "bad": 20, "angry": 8}
+
+    def test_system_names_labeled(self):
+        """The total contribution bars should be labeled with the system names."""
+        shift = ProportionShift(self.freq1, self.freq2)
+        ax = shift.get_shift_graph(
+            top_n=6, show_plot=False, system_names=["Corpus A", "Corpus B"]
+        )
+        labels = [t.get_text() for t in ax.texts]
+        assert "Corpus A" in labels
+        assert "Corpus B" in labels
+
+    def test_default_system_names_labeled(self):
+        """Falls back to the default system names when none are given."""
+        shift = ProportionShift(self.freq1, self.freq2)
+        ax = shift.get_shift_graph(top_n=6, show_plot=False)
+        labels = [t.get_text() for t in ax.texts]
+        assert "Text 1" in labels
+        assert "Text 2" in labels
+
+    def test_bars_remain_two_sided(self):
+        """Labeling must not flip every bar to one side (the broken workaround
+        of passing all_pos_contributions=True)."""
+        shift = ProportionShift(self.freq1, self.freq2)
+        ax = shift.get_shift_graph(top_n=6, show_plot=False)
+        widths = [p.get_width() for p in ax.patches if p.get_width() != 0]
+        assert any(w < 0 for w in widths)
+        assert any(w > 0 for w in widths)
+
+    def test_other_shifts_unaffected(self):
+        """Shifts that don't opt in keep empty total-bar symbols."""
+        freq1 = {"hello": 20, "world": 10}
+        freq2 = {"hello": 15, "world": 15}
+        scores = {"hello": 7.0, "world": 5.0}
+        shift = WeightedAvgShift(freq1, freq2, type2score_1=scores)
+        ax = shift.get_shift_graph(
+            top_n=2, show_plot=False, system_names=["Corpus A", "Corpus B"]
+        )
+        labels = [t.get_text() for t in ax.texts]
+        assert "Corpus A" not in labels
+        assert "Corpus B" not in labels


### PR DESCRIPTION
Fixes #47.

## Problem

`ProportionShift.get_shift_graph` leaves the cumulative bars at the top of the plot unlabeled, unlike the JSD shift graph where each system's name is written next to its purple/orange bar. As the issue reporter found, adding `all_pos_contributions=True` (the difference from the JSD definition) does add the names but breaks the plot by pushing every bar to the right-hand side.

## Cause

`all_pos_contributions` conflates two things in the plotting layer:

1. **Bar direction** — in `get_bar_dims`, it flips a type's bar based on the sign of `p_diff`. This is correct for JSD, whose contributions are inherently non-negative. But proportion shift scores *already* carry their sign (positive when a type is more prevalent in system 2, negative for system 1), so flipping forces every bar positive → all bars point right.
2. **Top-bar labels** — only the `all_pos_*` bar order uses the system names as symbols; the `neg_total`/`pos_total` bars used by ProportionShift have empty symbols.

So the reporter's workaround couldn't win: getting the labels also flipped the bars.

## Fix

Separate the two concerns. Add a `label_total_with_system_names` plot param that labels the `neg_total`/`pos_total` bars with the system names **without** changing bar direction, and enable it for `ProportionShift`. Those bars already share the same purple/orange colors as the JSD `all_pos_*` bars, so the result visually matches the JSD graph.

- `shifterator/plotting.py`: new `label_total_with_system_names` param (default `False`); when set, the `neg_total`/`pos_total` symbols become the system names.
- `shifterator/shifts.py`: `ProportionShift.get_shift_graph` opts in via `kwargs.setdefault(...)` so callers can still override.

## Tests

Added `TestIssue47ProportionShiftSystemNames` in `tests/test_issues.py`:

- system names appear on the graph (custom and default names)
- bars remain two-sided (regression guard against the all-right-side breakage)
- other shift types are unaffected

Full suite: 80 passed locally (`uv run pytest`).

## Note

This PR also bumps the version to `0.5.1` and exposes `shifterator.__version__`, so a branch install can be confirmed with `import shifterator; print(shifterator.__version__)`.